### PR TITLE
fix for encoding error when loading custom map with unicode

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -64,7 +64,7 @@ $(function() {
 				if((SOURCE_MAPPING_URL_REG_EXP.test(generatedSource) || SOURCE_MAPPING_URL_REG_EXP2.test(generatedSource)) && typeof atob == "function") {
 					var match = SOURCE_MAPPING_URL_REG_EXP.exec(generatedSource) || SOURCE_MAPPING_URL_REG_EXP2.exec(generatedSource);
 					try {
-						sourceMap = JSON.parse(atob(match[1]));
+						sourceMap = JSON.parse(decodeURIComponent(escape(window.atob(match[1]))));
 						return step3();
 					} catch(e) {}
 				}
@@ -274,7 +274,9 @@ $(function() {
 
 	function loadCustomExample(sourcesContent, generatedSource, sourceMap) {
 		loadExample(sourcesContent, generatedSource, sourceMap);
-		$(".custom-link").attr("href", "#base64," + [generatedSource, JSON.stringify(sourceMap)].concat(sourcesContent).map(btoa).join(",")).text("Link to this");
+		$(".custom-link").attr("href", "#base64," + [generatedSource, JSON.stringify(sourceMap)].concat(sourcesContent).map(function(str){
+    	return btoa(unescape(encodeURIComponent( str )));
+		}).join(",")).text("Link to this");
 	}
 	function loadExample(sources, exampleJs, exampleMap) {
 		var generated = $(".generated").hide().text("");


### PR DESCRIPTION
error message `'btoa' failed: The string to be encoded contains characters
outside of the Latin1 range` when some sourcesContent contains unicode

applied fix detailed in this MDN article 
https://developer.mozilla.org/en-US/docs/Web/API/Window.btoa

Couldn't test that the linking still works since interacting with the
"link here" link crashes my browser (my source map is 1.4MB)
