### PR TITLE
add less and file-loader to npm deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,17 @@
     "webpack-dev-server": "~1.2.x"
   },
   "dependencies": {
-    "source-map": "0.1.x",
-    "style-loader": "~0.6.0",
-    "url-loader": "~0.5.1",
-    "less-loader": "~0.7.0",
     "css-loader": "~0.6.0",
+    "file-loader": "^0.8.5",
+    "imports-loader": "~0.6.1",
     "jade-loader": "~0.5.0",
     "json-loader": "~0.5.0",
+    "less": "^1.7.5",
+    "less-loader": "~0.7.0",
     "raw-loader": "~0.5.0",
+    "source-map": "0.1.x",
+    "style-loader": "~0.6.0",
     "uglify-js": "~2.4.6",
-    "imports-loader": "~0.6.1"
+    "url-loader": "~0.5.1"
   }
 }


### PR DESCRIPTION
`file-loader` and `less` are required to build. Now explicitly added to the deps list.