### PR TITLE
Strip base64 sourcemap from generated source

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -64,6 +64,7 @@ $(function() {
 			function step2() {
 				if((SOURCE_MAPPING_URL_REG_EXP.test(generatedSource) || SOURCE_MAPPING_URL_REG_EXP2.test(generatedSource)) && typeof atob == "function") {
 					var match = SOURCE_MAPPING_URL_REG_EXP.exec(generatedSource) || SOURCE_MAPPING_URL_REG_EXP2.exec(generatedSource);
+					generatedSource = generatedSource.replace(SOURCE_MAPPING_URL_REG_EXP, "/* base64 source map removed */").replace(SOURCE_MAPPING_URL_REG_EXP2, "/* base64 source map removed */");
 					try {
 						sourceMap = JSON.parse(decodeURIComponent(escape(atob(match[1]))));
 						return step3();

--- a/app/app.js
+++ b/app/app.js
@@ -214,6 +214,7 @@ $(function() {
 					filesData.splice(filesData.indexOf(generatedFile), 1);
 					var generatedSource = generatedFile.result;
 					var match = SOURCE_MAPPING_URL_REG_EXP.exec(generatedSource) || SOURCE_MAPPING_URL_REG_EXP2.exec(generatedSource);
+					generatedFile.result = generatedFile.result.replace(SOURCE_MAPPING_URL_REG_EXP, "/* base64 source map removed */").replace(SOURCE_MAPPING_URL_REG_EXP2, "/* base64 source map removed */");
 					sourceMapFile = {
 						result: decodeURIComponent(escape(atob(match[1])))
 					};


### PR DESCRIPTION
So the page doesn't go crazy-wide and super-broken looking.

Currently it looks like this with an inline base64'd sourcemap.

![screen shot 2016-11-03 at 21 09 04-fullpage](https://cloud.githubusercontent.com/assets/49545/19994308/0582d2e8-a20a-11e6-964a-1cec1ba27d7a.png)

which is really hard to navigate. This change strips out that trailing comment using the same regexes that are used to match it in the first place. It also leaves a small explanatory comment at the end so people don't think the map just disappeared.

After the change, same file being inspected.

![screen shot 2016-11-03 at 21 12 27-fullpage](https://cloud.githubusercontent.com/assets/49545/19994330/3f41cd0e-a20a-11e6-914a-02d03140c54e.png)

If this needs any changes to better fit this code base please let me know, I'd be happy to make them.