### PR TITLE
escape html in input files

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -289,6 +289,7 @@ $(function() {
 			exampleMap.file = exampleMap.file || "example.js";
 			var map = new SourceMap.SourceMapConsumer(exampleMap);
 
+			visu.html(generateHtml(map, exampleJs, sources));
 			var results = generateHtml(map, exampleJs, sources);
 			visu.html(results.files);
 			footer.prepend(results.mappings);

--- a/app/app.js
+++ b/app/app.js
@@ -289,7 +289,6 @@ $(function() {
 			exampleMap.file = exampleMap.file || "example.js";
 			var map = new SourceMap.SourceMapConsumer(exampleMap);
 
-			visu.html(generateHtml(map, exampleJs, sources));
 			var results = generateHtml(map, exampleJs, sources);
 			visu.html(results.files);
 			footer.prepend(results.mappings);

--- a/app/generateHtml.js
+++ b/app/generateHtml.js
@@ -1,4 +1,5 @@
 var SourceMap = require("source-map");
+var escape = require("escape-html");
 var LINESTYLES = 5;
 var MAX_LINES = 5000;
 
@@ -34,7 +35,7 @@ module.exports = function(map, generatedCode, sources) {
 			return typeof attrs[key] !== "undefined";
 		}).map(function(key) {
 			return key + "=\"" + attrs[key] + "\"";
-		}).join(" ") + ">" + (text + "").replace(/</g, "&lt;") + "</span>";
+		}).join(" ") + ">" + text + "</span>";
 	}
 
 	var mapSources = map.sources;
@@ -138,12 +139,12 @@ module.exports = function(map, generatedCode, sources) {
 			currentOutputLine++;
 		}
 		if(mapSources.length > 1) {
-			addTo(originalSide, originalLine, "<h4>" + source.replace(/</g, "&lt;") + "</h4>");
+			addTo(originalSide, originalLine, "<h4>" + escape(source) + "</h4>");
 			originalLine++;
 		}
 		var exampleSource = sources[mapSources.indexOf(source)];
 		if(!exampleSource) throw new Error("Source '" + source + "' missing");
-		exampleLines = exampleSource.split("\n");
+		exampleLines = exampleSource.split("\n").map(escape);
 		currentSource = source;
 		mappings.forEach(function(mapping, idx) {
 			if(lastMapping) {
@@ -256,6 +257,4 @@ module.exports = function(map, generatedCode, sources) {
                originalSideElem + "</tbody></table></code></pre></div>",
         mappings: mappingsSideElem + "</tbody></table></code></pre></div>"
     };
-            
-        
 }

--- a/app/generateHtml.js
+++ b/app/generateHtml.js
@@ -1,24 +1,12 @@
 var SourceMap = require("source-map");
-var escape = require("escape-html");
+var escapeHTML = require("escape-html");
 var LINESTYLES = 5;
 var MAX_LINES = 5000;
 
-// Escape < >, etc
-// https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content
 function sanitize(text) {
-	var htmlEscapes = {
-		'&': '&amp;',
-		'<': '&lt;',
-		'>': '&gt;',
-		'"': '&quot;',
-		"'": '&#x27;',
-		'/': '&#x2F;'
-	};
-	var htmlEscaper = /[&<>"'\/]/g;
-
-	return text.replace(htmlEscaper, function(match) {
-			return htmlEscapes[match];
-	});
+	// Escape any <>'"\ during HTML serialization
+	// https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content
+	return escapeHTML(text);
 }
 
 module.exports = function(map, generatedCode, sources) {
@@ -31,9 +19,6 @@ module.exports = function(map, generatedCode, sources) {
 	}
 
 	function span(text, options) {
-
-		text = sanitize(text);
-
 		var attrs = {};
 		if(options) {
 			if(options.generated) {
@@ -56,7 +41,7 @@ module.exports = function(map, generatedCode, sources) {
 			return typeof attrs[key] !== "undefined";
 		}).map(function(key) {
 			return key + "=\"" + attrs[key] + "\"";
-		}).join(" ") + ">" + text + "</span>";
+		}).join(" ") + ">" + sanitize(text) + "</span>";
 	}
 
 	var mapSources = map.sources;
@@ -165,7 +150,7 @@ module.exports = function(map, generatedCode, sources) {
 		}
 		var exampleSource = sources[mapSources.indexOf(source)];
 		if(!exampleSource) throw new Error("Source '" + source + "' missing");
-		exampleLines = exampleSource.split("\n").map(escape);
+		exampleLines = exampleSource.split("\n");
 		currentSource = source;
 		mappings.forEach(function(mapping, idx) {
 			if(lastMapping) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "css-loader": "^0.23.1",
+    "escape-html": "^1.0.3",
     "file-loader": "^0.8.5",
     "imports-loader": "^0.6.1",
     "jade": "^1.11.0",


### PR DESCRIPTION
thanks a ton for building this tool! it's been incredibly useful for
me recently :)

when adding a source file with html in template strings, the app would
output lines without explicit mappings as html, and not as text:

![image](https://user-images.githubusercontent.com/1006268/33336713-13bde86c-d471-11e7-815b-24f34c98ea3f.png)

this fixes it and uses the robust escape-html module to do so:

![image](https://user-images.githubusercontent.com/1006268/33336354-ec8e1c68-d46f-11e7-8367-c0fdc9c855b1.png)