### PR TITLE
Calm colors, Skip ~ lines

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -73,7 +73,7 @@ header .btn-primary {
 }
 
 span.original-item {
-	border-left: 1px solid black;
+	// border-left: 1px solid black;
 	margin: 1px;
 	min-width: 3px;
 }
@@ -85,19 +85,19 @@ span.selected {
 	color: white;
 }
 .style-0 {
-	background: #FFFF66;
+	background: hsl(291.1, 46%, 87%);
 }
 .style-1 {
-	background: #FFFFFF;
+	background: hsl(198.9, 92%, 88%);
 }
 .style-2 {
-	background: #FFBBBB;
+	background: hsl(122, 37%, 89%);
 }
 .style-3 {
-	background: #AAFFFF;
+	background: hsl(53.8, 51%, 82%);
 }
 .style-4 {
-	background: #FFAAFF;
+	background: hsl(14.4, 31%, 82%);
 }
 
 pre {

--- a/app/generateHtml.js
+++ b/app/generateHtml.js
@@ -171,7 +171,7 @@ module.exports = function(map, generatedCode, sources) {
 					startLine.sort(function(a, b) { return a - b });
 					startLine = startLine[0];
 					while(typeof startLine !== "undefined" && currentOutputLine < startLine) {
-						addTo(originalSide, originalLine, "~");
+						// addTo(originalSide, originalLine, "~");
 						originalLine++;
 						currentOutputLine++;
 					}


### PR DESCRIPTION
Some nice pastels.

![image](https://user-images.githubusercontent.com/39191/37573487-ad231486-2ad5-11e8-97bd-556b5e96fb8a.png)

`~` do not need to be printed any-longer as with the new layout, side-by-side line-to-line comparison isn't as important.