### PR TITLE
Fix link to github.io app page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # source-map-visualization
 
-http://sokra.github.com/source-map-visualization/
+http://sokra.github.io/source-map-visualization/
 
 ## Contribute
 


### PR DESCRIPTION
The `.com` link was incorrect, so I fixed it.